### PR TITLE
Makefile: make golint install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ tools:
 	esac
 	go get -u golang.org/x/tools/cmd/goimports
 	go get -u golang.org/x/tools/cmd/cover
-	go get -u github.com/golang/lint/golint
+	go get -u golang.org/x/lint/golint
 
 test:
 	$(call print_status, Testing)


### PR DESCRIPTION
`golint` had moved at some point, and it was no longer installing correctly from the old location:

```
go get -u github.com/golang/lint/golint
package github.com/golang/lint/golint: code in directory /tmp/build/0284c6ac/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
```